### PR TITLE
Update IConsumerRegister.Default.cs to make dispose thread safe

### DIFF
--- a/src/DotNetCore.CAP/Internal/IConsumerRegister.Default.cs
+++ b/src/DotNetCore.CAP/Internal/IConsumerRegister.Default.cs
@@ -34,7 +34,7 @@ internal class ConsumerRegister : IConsumerRegister
     private IConsumerClientFactory _consumerClientFactory = default!;
     private CancellationTokenSource _cts = new();
     private IDispatcher _dispatcher = default!;
-    private bool _disposed;
+    private int _disposed;
     private bool _isHealthy = true;
 
     private MethodMatcherCache _selector = default!;
@@ -67,7 +67,7 @@ internal class ConsumerRegister : IConsumerRegister
 
         Execute();
 
-        _disposed = false;
+        _disposed = 0;
 
         return Task.CompletedTask;
     }
@@ -87,9 +87,8 @@ internal class ConsumerRegister : IConsumerRegister
 
     public void Dispose()
     {
-        if (_disposed) return;
-
-        _disposed = true;
+        if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 1)
+            return;
 
         try
         {


### PR DESCRIPTION
Add memory barrier to _disposed field to make Dispose call thread safe

### Description:
When doing Integration testing with WebApplicationFactory Class using xunit, tests tear down dispose twice.
One by CancelationToken, with stop method. This first call make CancelationTokenSource disposed, and every thing is fine.
After that WebApplicationFactory  is then disposed, and also call ConsumerRegister.Dispose.
Due to race condition, Pulse method is called a second time and try to dispose already disposed CancellationTokenSource.

It seems to be related to https://github.com/dotnet/aspnetcore/issues/40271


#### Changes:
- DotNetCore.CAP.Internal.ConsumerRegister.Dispose have been made thread safe

#### Affected components:
- DotNetCore.CAP.Internal.ConsumerRegister

#### How to test:
Add an Integration Test project with a WebApplicationFactory, run in Debug mode, exception is logged in Debug output.
Depending your host setup (old fashioned with program and startup class), exception causes test failure with error : 
Message:
[Test Collection Cleanup Failure (Data Integration Tests Collection)]: System.ObjectDisposedException : The CancellationTokenSource has been disposed.

      Stack Trace:
CancellationTokenSource.Cancel()
ConsumerRegister.Pulse() line 109
ConsumerRegister.Dispose() line 96
ServiceProviderEngineScope.DisposeAsync()
--- End of stack trace from previous location ---
Host.<DisposeAsync>g__DisposeAsync|16_0(Object o)
Host.DisposeAsync()
Host.Dispose()
WebApplicationFactory`1.DisposeAsync()
WebApplicationFactory`1.Dispose(Boolean disposing)
WebApplicationFactory`1.Dispose()


### Checklist:
- [X] I have tested my changes locally
- [X] My changes follow the project's code style guidelines

